### PR TITLE
cacheManger 싱글톤으로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,10 @@ project(':market-api') {
 
     }
 }
+project(':market-common') {
+    bootJar { enabled = false }
+    jar { enabled = true }
+}
 project(':market-core') {
     bootJar { enabled = false }
     jar { enabled = true }
@@ -100,7 +104,7 @@ project(':market-core') {
     def generated = "src/main/generated"
 
     sourceSets {
-        main.java.srcDirs += [ generated ]
+        main.java.srcDirs += [generated]
     }
 
     tasks.withType(JavaCompile) {

--- a/market-core/src/main/java/com/market/config/CacheConfig.java
+++ b/market-core/src/main/java/com/market/config/CacheConfig.java
@@ -4,8 +4,11 @@ import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.CachingConfigurerSupport;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.ehcache.EhCacheCacheManager;
+import org.springframework.cache.ehcache.EhCacheManagerFactoryBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.Objects;
 
 @Configuration
 @EnableCaching
@@ -14,6 +17,13 @@ public class CacheConfig extends CachingConfigurerSupport {
     @Bean
     @Override
     public CacheManager cacheManager() {
-        return new EhCacheCacheManager(new net.sf.ehcache.CacheManager());
+        return new EhCacheCacheManager(Objects.requireNonNull(ehCacheCacheManager().getObject()));
+    }
+
+    @Bean
+    public EhCacheManagerFactoryBean ehCacheCacheManager() {
+        EhCacheManagerFactoryBean factoryBean = new EhCacheManagerFactoryBean();
+        factoryBean.setShared(true);
+        return factoryBean;
     }
 }


### PR DESCRIPTION
cacheManger 싱글톤으로 변경했습니다.

추가적으로 root 모듈에서 빌드 할 때  market-common모듈의 bootJar 설정 때문에 
빌드가 안돼서 build.gradle에 아래 내용 추가했습니다.
```
project(':market-common') {
    bootJar { enabled = false }
    jar { enabled = true }
}
```

Closes: #19 